### PR TITLE
Fixed typos in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # We depend on the .git file inside the directory as git creates an empty dir
 # for us.
 $(FX2LIBDIR)/.git: .gitmodules
-	git submodule sync --recursive -- $$(dirname $@)
-	git submodule update --recursive --init $$(dirname $@)
-	touch $@ -r .gitmodules
+	git submodule sync --recursive -- $$(dirname .$@)
+	git submodule update --recursive --init $$(dirname .$@)
+	touch .$@ -r .gitmodules
 
 # FIXME: Add check_int2jit from hdmi2usb/Makefile


### PR DESCRIPTION
`$@` resolved to `/.git`, which is not found. Adding a `.` in front forced it to resolve to `./.git` in the current directory, allowing make to work as expected