### PR TITLE
Makfile: Use correct file paths and set variables

### DIFF
--- a/Makefile.fx2
+++ b/Makefile.fx2
@@ -14,6 +14,8 @@
 # use it to emulate a USB UVC Webcam and a USB CDC-ACM serial port.
 #
 
+MODESWITCH_CMD = hdmi2usb-mode-switch
+
 TARGETS += fx2
 
 help-fx2:
@@ -24,29 +26,29 @@ gateware-generate-fx2:
 	@true
 
 gateware-build-fx2:
-	cp gateware/encoder/vhdl/header.hex $(MSCDIR)/build/header.hex
+	cp gateware/streamer/vhdl/header.hex $(MSCDIR)/build/header.hex
 
 # Firmware for the Cypress FX2
-firmware-fx2: firmware/fx2/hdmi2usb.hex
+firmware-fx2: hdmi2usb/hdmi2usb.hex
 	@true
 
 embed-fx2: firmware/lm32/fx2_fw_hdmi2usb.c
 	@true
 
-load-fx2: firmware/fx2/hdmi2usb.hex
-	$(MODESWITCH_CMD) --load-fx2-firmware firmware/fx2/hdmi2usb.hex
+load-fx2: hdmi2usb/hdmi2usb.hex
+	$(MODESWITCH_CMD) --load-fx2-firmware hdmi2usb/hdmi2usb.hex
 
 flash-fx2:
 	@true
 
 clean-fx2:
-	$(MAKE) -C firmware/fx2 clean
+	$(MAKE) -C hdmi2usb clean
 
-firmware/fx2/hdmi2usb.hex:
-	$(MAKE) -C firmware/fx2
+hdmi2usb/hdmi2usb.hex:
+	$(MAKE) -C hdmi2usb
 
-firmware/lm32/fx2_fw_hdmi2usb.c: firmware/fx2/generate_fx2_microboot.py firmware/fx2/hdmi2usb.hex
-	firmware/fx2/generate_fx2_microboot.py firmware/fx2/hdmi2usb.hex > firmware/lm32/fx2_fw_hdmi2usb.c
+firmware/lm32/fx2_fw_hdmi2usb.c: microload/generate_2nd_stage.py hdmi2usb/hdmi2usb.hex
+	microload/generate_2nd_stage.py hdmi2usb/hdmi2usb.hex > firmware/lm32/fx2_fw_hdmi2usb.c
 
 # Utility functions
 view:

--- a/README.md
+++ b/README.md
@@ -78,3 +78,11 @@ FIXME: Put some documentation about the FX2 here.
 
  * [Further Documentation](https://reference.digilentinc.com/atlys:atlys:atlys)
 
+# Building
+
+    make -f Makefile.fx2 load-fx2
+
+will build and flash the FX2 firmware. This requires the `hdmi2usb-mode-switch`
+command, which on Debian Sid and Stretch can be installed using the
+`hdmi2usb-mode-switch` package, otherwise see
+[HDMI2USB-mode-switch](https://github.com/timvideos/HDMI2USB-mode-switch).

--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ will build and flash the FX2 firmware. This requires the `hdmi2usb-mode-switch`
 command, which on Debian Sid and Stretch can be installed using the
 `hdmi2usb-mode-switch` package, otherwise see
 [HDMI2USB-mode-switch](https://github.com/timvideos/HDMI2USB-mode-switch).
+
+There are three ways to run `hdmi2usb-mode-switch`:
+
+ 1. As root
+ 1. Install the
+ [unbind-helper](https://github.com/timvideos/HDMI2USB-mode-switch/blob/master/unbind-helper.c)
+ as a setuid binary
+ 1. Install the
+ [udev-rules](https://github.com/timvideos/HDMI2USB-mode-switch/tree/master/udev)
+ which sets the permissions of the unbind.

--- a/hdmi2usb/Makefile
+++ b/hdmi2usb/Makefile
@@ -141,7 +141,7 @@ check: check_int2jt
 
 clean:
 	$(Q_RM)$(RM) *.iic *.asm *.lnk *.lst *.map *.mem *.rel *.rst *.sym \
-		*.lk progOffsets.h firmware.hex date.inc
+		*.lk progOffsets.h hdmi2usb.hex date.inc
 	cd $(FX2LIBDIR) && make clean
 
 distclean: clean


### PR DESCRIPTION
Makes the firmware build correctly and flash the FX2 chip. Also added instructions to the README for building and flashing the firmware