### PR TITLE
examples/lights: Fix bitmask name

### DIFF
--- a/examples/lights/lights.c
+++ b/examples/lights/lights.c
@@ -23,7 +23,7 @@
 
 void init_lights(void) {
     // Set pins to port mode instead of GPIF master/slave mode
-    IFCONFIG &= ~(bmIFCONFGMASK);
+    IFCONFIG &= ~(bmIFCFGMASK);
     PORTACFG = 0x00;
 }
 


### PR DESCRIPTION
The bitmask name was wrong. Somehow I did not pick it up previously