### PR TITLE
Generate documentation from Travis

### DIFF
--- a/.travis-push-docs.sh
+++ b/.travis-push-docs.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+set -e
+
+if [ "$TRAVIS" = true -a "$TRAVIS_SECURE_ENV_VARS" = false ]; then
+	echo "No environment variables found, skipping (probably a pull request)."
+	exit 0
+fi
+
+if [ "$TRAVIS" = true -a "$TRAVIS_BRANCH" != "master" ]; then
+	echo "No master branch, skipping."
+	exit 0
+fi
+
+if [ -z "$TRAVIS_REPO_SLUG" ]; then
+	echo "No TRAVIS_REPO_SLUG value found."
+	echo "Please set this if running outside Travis."
+	exit 0
+fi
+
+# FIXME: Replace this with a deploy key, so you don't end up with tokens which
+# potentially give people *a lot* of access to your GitHub repos.
+if [ -z "$GH_TOKEN" ]; then
+	echo "No GH_TOKEN value found."
+	echo
+	echo "Generate a GitHub token at https://github.com/settings/tokens/new"
+	echo "with *only* the public_repo option."
+	echo "Then go to https://travis-ci.org/$TRAVIS_REPO_SLUG/settings and"
+	echo "add an 'Environment Variables' with the following;"
+	echo " * Name == GH_TOKEN"
+	echo " * Value == your token value from above"
+	echo " * Display value in build log == OFF"
+	echo
+	echo "It is important that you protect this token, as it has full push"
+	echo "access to your repos!"
+	exit 1
+fi
+
+if [ -z "$GIT_NAME" ]; then
+	echo "No GIT_NAME value found."
+	echo
+	echo "Then go to https://travis-ci.org/$TRAVIS_REPO_SLUG/settings and"
+	echo "add an 'Environment Variables' with the following;"
+	echo " * Name == GIT_NAME"
+	echo " * Value == Human readable name for the commit author."
+	echo "       Something like \"Tim Ansell's Robot\" is a good choice."
+	echo " * Display value in build log == ON"
+	exit 1
+fi
+
+if [ -z "$GIT_EMAIL" ]; then
+	echo "No GIT_EMAIL value found."
+	echo
+	echo "Then go to https://travis-ci.org/$TRAVIS_REPO_SLUG/settings and"
+	echo "add an 'Environment Variables' with the following;"
+	echo " * Name == GIT_EMAIL"
+	echo " * Value == Email address the commit author."
+	echo "       Set up an email address, or use your own."
+	echo " * Display value in build log == ON"
+	exit 1
+fi
+
+TMPDIR=$(mktemp --directory)
+
+if ! git describe --always > /dev/null 2>&1; then
+	echo "- Fetching non shallow to get git version"
+	git fetch --unshallow && git fetch --tags
+fi
+ORIG_GIT_REVISION=`git describe --always`
+ORIG_COMMITTER_NAME=$(git log -1 --pretty=%an)
+ORIG_COMMITTER_EMAIL=$(git log -1 --pretty=%ae)
+
+echo "- Setting up the output"
+cp -aRf docs/html/* $TMPDIR/
+find $TMPDIR | sort
+
+echo "- Switching to the gh-pages branch"
+git remote set-branches --add origin gh-pages
+git fetch origin gh-pages
+git checkout origin/gh-pages -b gh-pages
+
+echo "- Adding the newly generated content"
+rm -rf *
+cp -aRf $TMPDIR/* .
+git add -v -A .
+
+echo "- Committing"
+export GIT_AUTHOR_EMAIL="$ORIG_COMMITTER_EMAIL"
+export GIT_AUTHOR_NAME="$ORIG_COMMITTER_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_NAME"
+export GIT_COMMITTER_NAME="$GIT_EMAIL"
+unset GIT_NAME
+unset GIT_EMAIL
+git commit -a -m "Travis build #$TRAVIS_BUILD_NUMBER of $ORIG_GIT_REVISION"
+
+echo "- Pushing"
+git remote set-url origin https://$GH_TOKEN@github.com/$TRAVIS_REPO_SLUG.git > /dev/null 2>&1
+git push origin gh-pages > /dev/null 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 
 install:
     - # Install sdcc and as31
-    - sudo apt-get install --force-yes -y sdcc as31
+    - sudo apt-get install --force-yes -y as31 doxygen sdcc
     - sdcc --version
 
 script:
@@ -11,3 +11,7 @@ script:
     - make firmware-audio-fx2
     - make firmware-unconfigured
     - make microload
+    - make docs
+
+after_success:
+    - ./.travis-push-docs.sh


### PR DESCRIPTION
For this to work: 

 1) gh-pages branch needs to exist in the repo. 
 1) Generate a GitHub [token](https://github.com/settings/tokens/new) with only the public_repo option
 1) Add this as an environment variable named `GH_TOKEN` on [Travis](https://travis-ci.org/timvideos/HDMI2USB-fx2-firmware/settings) and set the display value to off
 1) Add an environment variable `GIT_NAME` with the name of the commit author.
 1) Add an environment variable `GIT_EMAIL` with the email of the commit author.

